### PR TITLE
Pass the context while calling the callback in apply function and not as a property of an object.

### DIFF
--- a/pubsub.js
+++ b/pubsub.js
@@ -42,10 +42,10 @@
 				if(typeof subscription === 'object' && executedSubscriptions.hasOwnProperty(subscriptionId)) {
 					if(async) {
 						setTimeout(function() {
-							subscription.callback.apply(subscription.object, args);
+							subscription.callback.apply(subscription.context, args);
 						}, 4);
 					} else {
-						subscription.callback.apply(subscription.object, args);
+						subscription.callback.apply(subscription.context, args);
 					}
 				}
 			});
@@ -149,7 +149,7 @@
 
 			eventObject = {
 				callback	: callback,
-				object  	: contextObject // "this" parameter in executed function
+				context  	: contextObject.context // "this" parameter in executed function
 			};
 
 			nsObject._events.push(eventObject);


### PR DESCRIPTION
As per the standards followed everywhere in the world, context should directly be passed in apply as first argument but not a property inside an object. Currently, callback is called with the "subscription.object"(line 45 and 48) which has context inside it but the context should directly be sent as first argument and not as a property of an object. eventObject(line 151) should contain its callback and the context in which callback is going to be executed but here the object is passed and in the callback, it is expected to read the context(this) from the passed object.
Fix for the same in this pull request.